### PR TITLE
fix(build): ignore semantic-release errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lint": "eslint src test --ignore-path .gitignore",
     "prepublish": "babel src -d lib",
     "pretest": "npm run lint",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post",
+    "semantic-release": "semantic-release pre || exit 0; && npm publish && semantic-release post",
     "access": "npm-run-all --parallel access:*",
     "access:editorial": "npm access grant read-only economist:economist-editorial $npm_package_name",
     "access:infographics": "npm access grant read-only economist:infographics $npm_package_name",


### PR DESCRIPTION
semantic-release will exit with non-zero exit codes if there is no new
version to release, as such, any `chore`/`style`/`doc` only commits will
fail the build. This change makes it so that the exit code semantic
release emits is ignored, and the build will pass, even if it fails.