### PR TITLE
Fix small text in examples.

### DIFF
--- a/templates/style.css
+++ b/templates/style.css
@@ -3,7 +3,6 @@ html, body {
   padding: 0;
   font-family: sans-serif;
   color: #424242;
-  font-size: 16px;
   font-variant-numeric: lining-nums;
   background: #fafafa;
 }


### PR DESCRIPTION
This shouldn't be done from here as it goes over what is set in @component-typography, making all of our components' demos have small text.

What should happen is that any component which requires typography allows typography to override the global value in its example. If it doesn't require typography then we have no problem in the first place.